### PR TITLE
Fix install path

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,8 @@ set -e
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-LP_DIR=`cd $(dirname $0); cd ..; pwd`
+BIN_DIR=$(cd $(dirname $0); pwd)
+source $BIN_DIR/utils
 
 mkdir -p $CACHE_DIR
 cd $CACHE_DIR
@@ -24,11 +25,13 @@ else
 	fi
 fi
 
+start-build-in-dir $HOME
+
 if hash lilypond 2>/dev/null; then
 	echo "-----> LilyPond already installed"
 else
 	echo "-----> Installing LilyPond"
-	sh lilypond-2.18.2-1.linux-64.sh --prefix=/app/ --batch
+	sh lilypond-2.18.2-1.linux-64.sh --prefix=$HOME --batch
 fi
 
 echo "-----> Testing LilyPond"
@@ -43,4 +46,5 @@ else
 	exit 1;
 fi
 
+end-build-in-dir
 echo "-----> Done installing LilyPond"

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,8 @@ CACHE_DIR=$2
 BIN_DIR=$(cd $(dirname $0); pwd)
 source $BIN_DIR/utils
 
+start-build-in-dir $HOME
+
 mkdir -p $CACHE_DIR
 cd $CACHE_DIR
 file1="lilypond-2.18.2-1.linux-64.sh"
@@ -24,8 +26,6 @@ else
 	    exit 1;
 	fi
 fi
-
-start-build-in-dir $HOME
 
 if hash lilypond 2>/dev/null; then
 	echo "-----> LilyPond already installed"

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ CACHE_DIR=$2
 BIN_DIR=$(cd $(dirname $0); pwd)
 source $BIN_DIR/utils
 
-start-build-in-dir $HOME
+start-build-in-home
 
 mkdir -p $CACHE_DIR
 cd $CACHE_DIR
@@ -46,5 +46,5 @@ else
 	exit 1;
 fi
 
-end-build-in-dir
+finish-build-in-home
 echo "-----> Done installing LilyPond"

--- a/bin/compile
+++ b/bin/compile
@@ -31,12 +31,12 @@ if hash lilypond 2>/dev/null; then
 	echo "-----> LilyPond already installed"
 else
 	echo "-----> Installing LilyPond"
-	sh lilypond-2.18.2-1.linux-64.sh --prefix=$HOME --batch
+	sh lilypond-2.18.2-1.linux-64.sh --prefix=$HOME --batch | indent
 fi
 
 echo "-----> Testing LilyPond"
 echo \\header{title = \"A scale in LilyPond\"} \\relative {c d e f g a b c} \\version \"2.18.2\" > blah.ly
-lilypond --png -o blahOutput blah.ly
+lilypond --png -o blahOutput blah.ly | indent
 if [ -f $file1 ]
 then
 	echo "-----> Test passed"

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ fi
 
 echo "-----> Testing LilyPond"
 echo \\header{title = \"A scale in LilyPond\"} \\relative {c d e f g a b c} \\version \"2.18.2\" > blah.ly
-lilypond --png -o blahOutput blah.ly | indent
+lilypond --png -o blahOutput blah.ly 2>&1 | indent
 if [ -f $file1 ]
 then
 	echo "-----> Test passed"

--- a/bin/utils
+++ b/bin/utils
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+shopt -s extglob
+
+[ $(uname) == "Darwin" ] && SED_FLAG='-l' || SED_FLAG='-u'
+
+# Syntax sugar.
+indent() {
+  RE="s/^/       /"
+  sed $SED_FLAG "$RE"
+}
+
+# Clean up pip output
+cleanup() {
+  sed $SED_FLAG -e 's/\.\.\.\+/.../g' | sed $SED_FLAG '/already satisfied/Id' | sed $SED_FLAG -e '/Overwriting/Id' |  sed $SED_FLAG -e '/python executable/Id' | sed $SED_FLAG -e '/no previously-included files/Id'
+}
+
+# Buildpack Steps.
+function puts-step (){
+  echo "-----> $@"
+}
+
+# Buildpack Warnings.
+function puts-warn (){
+  echo " !     $@"
+}
+
+# Initialise profile file in .profile.d/
+# Usage: $ init-profile-file "conda.sh"
+init-profile-file() {
+  PROFILE_PATH="${BUILD_DIR}/.profile.d/${1}"
+  export PROFILE_PATH
+  mkdir -p $(dirname $PROFILE_PATH)
+  echo "Initialised profile file at ${PROFILE_PATH}" | indent
+}
+
+# Usage: $ echo-profile-file
+echo-profile-file() {
+  echo "Content of ${PROFILE_PATH}:" | indent
+  cat "${PROFILE_PATH}" | indent
+}
+
+# Usage: $ set-env key value
+function set-env (){
+  echo "export $1=$2" >> $PROFILE_PATH
+}
+
+# Usage: $ set-default-env key value
+function set-default-env (){
+  echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
+}
+
+# Usage: $ set-default-env key value
+function un-set-env (){
+  echo "unset $1" >> $PROFILE_PATH
+}
+
+# Does some serious copying.
+function deep-cp (){
+  find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec cp -a '{}' $2 \;
+  cp -r $1/!(tmp) $2
+  # echo copying $1 to $2
+}
+
+# Does some serious moving.
+function deep-mv (){
+  deep-cp $1 $2
+
+  rm -fr $1/!(tmp)
+  find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec rm -fr '{}' \;
+}
+
+# Usage: $ start-build-in-dir "${HOME}"
+start-build-in-dir() {
+  echo "Start building in ${1}." | indent
+  ORIG_BUILD_DIR=${BUILD_DIR}
+  BUILD_DIR=${1}
+  mkdir /tmp/home
+  deep-mv "${HOME}" /tmp/home
+  deep-mv "${ORIG_BUILD_DIR}" "${BUILD_DIR}"
+  cd "${BUILD_DIR}"
+}
+
+# Usage: $ end-build-in-dir
+end-build-in-dir() {
+  echo "Finish building in ${BUILD_DIR}." | indent
+  deep-mv "${BUILD_DIR}" "${ORIG_BUILD_DIR}"
+  deep-mv /tmp/home "${HOME}"
+}

--- a/bin/utils
+++ b/bin/utils
@@ -3,7 +3,7 @@ shopt -s extglob
 
 [ $(uname) == "Darwin" ] && SED_FLAG='-l' || SED_FLAG='-u'
 
-# Syntax sugar.
+# Indent output as per Heroku style guide.
 indent() {
   RE="s/^/       /"
   sed $SED_FLAG "$RE"
@@ -13,7 +13,6 @@ indent() {
 function deep-cp (){
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec cp -a '{}' $2 \;
   cp -r $1/!(tmp) $2
-  # echo copying $1 to $2
 }
 
 # Does some serious moving.
@@ -40,7 +39,7 @@ start-build-in-home() {
   cd "${BUILD_DIR}"
 }
 
-# Restore build directory tweaks
+# Restore build directory tweaks.
 #
 # Moves home directory content back to Heroku's build directory (otherwise it
 # won't be packaged up) and move /tmp/home back to home directory. Use this 

--- a/bin/utils
+++ b/bin/utils
@@ -9,51 +9,6 @@ indent() {
   sed $SED_FLAG "$RE"
 }
 
-# Clean up pip output
-cleanup() {
-  sed $SED_FLAG -e 's/\.\.\.\+/.../g' | sed $SED_FLAG '/already satisfied/Id' | sed $SED_FLAG -e '/Overwriting/Id' |  sed $SED_FLAG -e '/python executable/Id' | sed $SED_FLAG -e '/no previously-included files/Id'
-}
-
-# Buildpack Steps.
-function puts-step (){
-  echo "-----> $@"
-}
-
-# Buildpack Warnings.
-function puts-warn (){
-  echo " !     $@"
-}
-
-# Initialise profile file in .profile.d/
-# Usage: $ init-profile-file "conda.sh"
-init-profile-file() {
-  PROFILE_PATH="${BUILD_DIR}/.profile.d/${1}"
-  export PROFILE_PATH
-  mkdir -p $(dirname $PROFILE_PATH)
-  echo "Initialised profile file at ${PROFILE_PATH}" | indent
-}
-
-# Usage: $ echo-profile-file
-echo-profile-file() {
-  echo "Content of ${PROFILE_PATH}:" | indent
-  cat "${PROFILE_PATH}" | indent
-}
-
-# Usage: $ set-env key value
-function set-env (){
-  echo "export $1=$2" >> $PROFILE_PATH
-}
-
-# Usage: $ set-default-env key value
-function set-default-env (){
-  echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
-}
-
-# Usage: $ set-default-env key value
-function un-set-env (){
-  echo "unset $1" >> $PROFILE_PATH
-}
-
 # Does some serious copying.
 function deep-cp (){
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec cp -a '{}' $2 \;
@@ -69,19 +24,28 @@ function deep-mv (){
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec rm -fr '{}' \;
 }
 
-# Usage: $ start-build-in-dir "${HOME}"
-start-build-in-dir() {
-  echo "Start building in ${1}." | indent
+# Tweak directories to build the app in the home directory (/app) instead of 
+# Heroku's build directory.
+# 
+# Moves existing content in home to /tmp/home and moves build directory content 
+# to the home directory. Use this at the beginning of the build process.
+start-build-in-home() {
+  echo "Start building in ${HOME}." | indent
   ORIG_BUILD_DIR=${BUILD_DIR}
-  BUILD_DIR=${1}
+  # Re-set $BUILD_DIR!
+  BUILD_DIR=${HOME}
   mkdir -p /tmp/home
   deep-mv "${HOME}" /tmp/home
   deep-mv "${ORIG_BUILD_DIR}" "${BUILD_DIR}"
   cd "${BUILD_DIR}"
 }
 
-# Usage: $ end-build-in-dir
-end-build-in-dir() {
+# Restore build directory tweaks
+#
+# Moves home directory content back to Heroku's build directory (otherwise it
+# won't be packaged up) and move /tmp/home back to home directory. Use this 
+# at the end of the build process.
+finish-build-in-home() {
   echo "Finish building in ${BUILD_DIR}." | indent
   deep-mv "${BUILD_DIR}" "${ORIG_BUILD_DIR}"
   deep-mv /tmp/home "${HOME}"

--- a/bin/utils
+++ b/bin/utils
@@ -74,7 +74,7 @@ start-build-in-dir() {
   echo "Start building in ${1}." | indent
   ORIG_BUILD_DIR=${BUILD_DIR}
   BUILD_DIR=${1}
-  mkdir /tmp/home
+  mkdir -p /tmp/home
   deep-mv "${HOME}" /tmp/home
   deep-mv "${ORIG_BUILD_DIR}" "${BUILD_DIR}"
   cd "${BUILD_DIR}"


### PR DESCRIPTION
Hi

Was just trying this Lilypond buildpack and discovered it's not quite working for me because Lilypond is not installed into the Heroku build dir. I have implemented a fix using similar approach as used in https://github.com/kennethreitz/conda-buildpack. This basically installs stuff in `/app` but then copies it back to `$BUILD_DIR` at the end. See what you think.